### PR TITLE
chore: update proto definitions to v2025.1117.170000

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@n-air-app/nicolive-comment-protobuf",
-  "version": "2025.602.163750",
+  "version": "2025.1117.170000",
   "description": "nicolive protobuf module for TypeScript",
   "main": "dist/index.js",
   "files": [

--- a/proto/dwango/nicolive/chat/data/atoms/akashic.proto
+++ b/proto/dwango/nicolive/chat/data/atoms/akashic.proto
@@ -1,0 +1,30 @@
+syntax = "proto3";
+
+package dwango.nicolive.chat.data.atoms;
+import "google/protobuf/struct.proto";
+
+message AkashicMessageEvent {
+  
+  string type = 1;
+  
+  string playId = 2;
+  
+  bool ignorable = 3;
+  
+  bool transient = 4;
+  
+  google.protobuf.Struct parameters = 5;
+}
+
+message AkashicStateRouting {
+  int64 epoch = 1;
+
+  
+  repeated AkashicMessageEvent join = 2;
+
+  
+  repeated AkashicMessageEvent continuation = 3;
+
+  
+  repeated AkashicMessageEvent shared = 4;
+}

--- a/proto/dwango/nicolive/chat/data/atoms/ichibalauncher.proto
+++ b/proto/dwango/nicolive/chat/data/atoms/ichibalauncher.proto
@@ -1,0 +1,51 @@
+syntax = "proto3";
+
+package dwango.nicolive.chat.data.atoms;
+
+message IchibaLauncherItemSet {
+  message Item {
+    
+    string id = 1;
+
+    
+    string entityId = 2;
+
+    
+    string serviceName = 3;
+
+    
+    string title = 4;
+
+    
+    enum LaunchDialogType {
+      SMALL = 0; 
+      RICHIVIEW = 1; 
+    }
+    LaunchDialogType launchDialogType = 5;
+
+    
+    string thumbnailUrl = 6;
+
+    
+    int32 thumbnailWidth = 7;
+
+    
+    int32 thumbnailHeight = 8;
+
+    
+    string launchUrl = 9;
+
+    
+    optional string addedUserId = 10;
+
+    
+    optional string reportUrl = 11;
+
+    
+    bool running = 12; 
+  }
+
+  int64 epoch = 1;
+
+  repeated Item items = 2;
+}

--- a/proto/dwango/nicolive/chat/data/atoms/notifications.proto
+++ b/proto/dwango/nicolive/chat/data/atoms/notifications.proto
@@ -29,6 +29,9 @@ message SimpleNotificationV2 {
 
     
     USER_LEVEL_UP = 8;
+
+    
+    USER_FOLLOW = 9;
   }
   
   NotificationType type = 1;

--- a/proto/dwango/nicolive/chat/data/atoms/streamstate.proto
+++ b/proto/dwango/nicolive/chat/data/atoms/streamstate.proto
@@ -1,0 +1,15 @@
+syntax = "proto3";
+
+package dwango.nicolive.chat.data.atoms;
+
+message StreamStateChange {
+  int64 epoch = 1;
+
+  enum State {
+    PASSTHROUGH = 0; 
+    PROCESSED = 1; 
+  }
+
+  
+  State state = 2;
+}

--- a/proto/dwango/nicolive/chat/data/message.proto
+++ b/proto/dwango/nicolive/chat/data/message.proto
@@ -5,6 +5,7 @@ import "dwango/nicolive/chat/data/atoms.proto";
 import "dwango/nicolive/chat/data/atoms/forwarded.proto";
 import "dwango/nicolive/chat/data/atoms/moderator.proto";
 import "dwango/nicolive/chat/data/atoms/notifications.proto";
+import "dwango/nicolive/chat/data/atoms/akashic.proto";
 
 
 
@@ -43,6 +44,9 @@ message NicoliveMessage {
 
     
     atoms.SimpleNotificationV2 simple_notification_v2 = 23;
+
+    
+    atoms.AkashicMessageEvent akashic_message_event = 24;
   }
 
   reserved 2 to 6, 10 to 12, 14 to 16;

--- a/proto/dwango/nicolive/chat/data/state.proto
+++ b/proto/dwango/nicolive/chat/data/state.proto
@@ -4,6 +4,9 @@ package dwango.nicolive.chat.data;
 
 import "dwango/nicolive/chat/data/atoms.proto";
 import "dwango/nicolive/chat/data/atoms/moderator.proto";
+import "dwango/nicolive/chat/data/atoms/akashic.proto";
+import "dwango/nicolive/chat/data/atoms/ichibalauncher.proto";
+import "dwango/nicolive/chat/data/atoms/streamstate.proto";
 
 message NicoliveState {
 
@@ -35,4 +38,13 @@ message NicoliveState {
 
   
   optional atoms.ModerationAnnouncement moderation_announcement = 10;
+
+  
+  optional atoms.IchibaLauncherItemSet ichiba_launcher = 11;
+
+  
+  optional atoms.StreamStateChange stream_state_change = 12;  
+
+  
+  optional atoms.AkashicStateRouting akashic_state = 13;
 }


### PR DESCRIPTION
## Summary
- Update proto definitions from source repository v2025.1117.170000
- Add new proto definitions: akashic, ichibalauncher, streamstate
- Update notifications, message, and state proto definitions

## Test plan
- [x] Run `npm run update-proto`
- [x] Run `npm run build`
- [x] Run `npm test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)