### PR TITLE
test: normalize proto3 default values in encode/decode roundtrip comparison

### DIFF
--- a/test/use-from-ts.test.ts
+++ b/test/use-from-ts.test.ts
@@ -54,10 +54,16 @@ describe('encode and decode', () => {
     );
 
     // decode and compare
+    const ChunkedMessage = dwango.nicolive.chat.service.edge.ChunkedMessage;
     const reader = new Reader(encoded);
     for (const message of messages) {
-      const decoded = dwango.nicolive.chat.service.edge.ChunkedMessage.decodeDelimited(reader);
-      expect(JSON.stringify(decoded)).toEqual(JSON.stringify(message));
+      const decoded = ChunkedMessage.decodeDelimited(reader);
+      // proto3 ではデフォルト値 (enum 0 等) が wire format に乗らないため、
+      // 期待値も同じ encode/decode を経由させて正規化してから比較する
+      const normalized = ChunkedMessage.decode(
+        ChunkedMessage.encode(ChunkedMessage.fromObject(message)).finish()
+      );
+      expect(JSON.stringify(decoded)).toEqual(JSON.stringify(normalized));
     }
   });
 });


### PR DESCRIPTION
## Summary

- `test/use-from-ts.test.ts` の encode/decode ラウンドトリップ比較を proto3 セマンティクスに対応させる
- proto3 wire format ではデフォルト値 (enum 0 等) がドロップされるため、期待値も同じ encode/decode を経由して正規化してから比較する
- 現行の protobufjs@8.0.3 では動作に変更なし (両側ともに `operation:0` が含まれるため)
- 将来の protobufjs 8.4.0 以降へのアップデート (PR #100) でもテストが通るようになる準備

## Test plan

- [ ] `npm test` が main (protobufjs@8.0.3) で green になることを CI で確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)