### PR TITLE
feat: クリエイターサポート特典のメッセージを追加 (ndgr-edge-proto v2026.0616.161033)

### DIFF
--- a/proto/dwango/nicolive/chat/data/atoms/creatorsupport.proto
+++ b/proto/dwango/nicolive/chat/data/atoms/creatorsupport.proto
@@ -1,0 +1,37 @@
+syntax = "proto3";
+
+package dwango.nicolive.chat.data.atoms;
+
+message CreatorSupportGoalStatus {
+  
+  bool displayEnabled = 1;
+
+  message GoalStatus {
+    
+    string rewardName = 2;
+
+    
+    string rewardDisplayName = 3;
+
+    
+    
+    double progressRatio = 4;
+
+    
+    
+    int64 currentPoint = 5;
+
+    
+    int64 lowerPoint = 6;
+
+    
+    int64 upperPoint = 7;
+
+    
+    
+    bool isAchieved = 8;
+  }
+
+  
+  optional GoalStatus goalStatus = 2;
+}

--- a/proto/dwango/nicolive/chat/data/atoms/notifications.proto
+++ b/proto/dwango/nicolive/chat/data/atoms/notifications.proto
@@ -32,6 +32,9 @@ message SimpleNotificationV2 {
 
     
     USER_FOLLOW = 9;
+
+    
+    CREATOR_SUPPORT_GOAL_ACHIRVEMENT = 10;
   }
   
   NotificationType type = 1;

--- a/proto/dwango/nicolive/chat/data/message.proto
+++ b/proto/dwango/nicolive/chat/data/message.proto
@@ -8,6 +8,7 @@ import "dwango/nicolive/chat/data/atoms/notifications.proto";
 import "dwango/nicolive/chat/data/atoms/akashic.proto";
 import "dwango/nicolive/chat/data/atoms/features.proto";
 import "dwango/nicolive/chat/data/atoms/cruise.proto";
+import "dwango/nicolive/chat/data/atoms/creatorsupport.proto";
 
 
 

--- a/proto/dwango/nicolive/chat/data/state.proto
+++ b/proto/dwango/nicolive/chat/data/state.proto
@@ -7,6 +7,7 @@ import "dwango/nicolive/chat/data/atoms/moderator.proto";
 import "dwango/nicolive/chat/data/atoms/akashic.proto";
 import "dwango/nicolive/chat/data/atoms/ichibalauncher.proto";
 import "dwango/nicolive/chat/data/atoms/streamstate.proto";
+import "dwango/nicolive/chat/data/atoms/creatorsupport.proto";
 
 message NicoliveState {
 
@@ -47,4 +48,7 @@ message NicoliveState {
 
   
   optional atoms.AkashicStateRouting akashic_state = 13;
+
+  
+  optional atoms.CreatorSupportGoalStatus creator_support_goal_status = 14;
 }

--- a/test/use-from-ts.test.ts
+++ b/test/use-from-ts.test.ts
@@ -66,4 +66,46 @@ describe('encode and decode', () => {
       expect(JSON.stringify(decoded)).toEqual(JSON.stringify(normalized));
     }
   });
+
+  it('should encode and decode creatorSupportGoalStatus in State message', () => {
+    const messages: dwango.nicolive.chat.service.edge.IChunkedMessage[] = [
+      {
+        state: {
+          creatorSupportGoalStatus: {
+            displayEnabled: true,
+            goalStatus: {
+              rewardName: 'reward',
+              rewardDisplayName: '目標達成報酬',
+              progressRatio: 0.42,
+              currentPoint: 4200,
+              lowerPoint: 0,
+              upperPoint: 10000,
+              isAchieved: false,
+            },
+          },
+        },
+      },
+    ];
+
+    // encode
+    const encoded = Uint8Array.from(
+      messages
+        .map(message => dwango.nicolive.chat.service.edge.ChunkedMessage.encodeDelimited(message).finish())
+        .map((b) => Array.from(b))
+        .flat()
+    );
+
+    // decode and compare
+    const ChunkedMessage = dwango.nicolive.chat.service.edge.ChunkedMessage;
+    const reader = new Reader(encoded);
+    for (const message of messages) {
+      const decoded = ChunkedMessage.decodeDelimited(reader);
+      // proto3 ではデフォルト値 (enum 0 等) が wire format に乗らないため、
+      // 期待値も同じ encode/decode を経由させて正規化してから比較する
+      const normalized = ChunkedMessage.decode(
+        ChunkedMessage.encode(ChunkedMessage.fromObject(message)).finish()
+      );
+      expect(JSON.stringify(decoded)).toEqual(JSON.stringify(normalized));
+    }
+  });
 });


### PR DESCRIPTION
## 概要

上流リポジトリ [ndgr-edge-proto](https://github.com/nico-live/ndgr-edge-proto) のリリース [v2026.0616.161033](https://github.com/nico-live/ndgr-edge-proto/releases/tag/v2026.0616.161033) を取り込みました。

本リリースの本体は **クリエイターサポート特典** に関する定義の追加で、次の2つの独立した仕組みから成ります。

1. **目標達成の通知** — `SimpleNotificationV2` システム通知メッセージの通知種別として `CREATOR_SUPPORT_GOAL_ACHIRVEMENT` を追加。目標達成時はこの種別で通知が送られます（通知自体は既存の SimpleNotificationV2 を流用、独立メッセージではありません）。
2. **目標の進捗状況** — `CreatorSupportGoalStatus` という独立メッセージを新規追加し、`NicoliveState`（State）の `creator_support_goal_status` フィールドとして配信されます。

`npm run update-proto` で proto 定義を同期し、`npm run build` で生成物を更新しています（`dist/` は gitignore 対象のため publish 時に `prepack` で生成）。

## 変更内容

| ファイル | 変更 |
| --- | --- |
| `atoms/notifications.proto` | `SimpleNotificationV2.NotificationType` に目標達成通知 `CREATOR_SUPPORT_GOAL_ACHIRVEMENT = 10` を追加（enum 名のスペルは上流原文ママ） |
| `atoms/creatorsupport.proto` | 新規追加。目標の進捗状況を表す独立メッセージ `CreatorSupportGoalStatus`（ネスト `GoalStatus` を含む） |
| `data/state.proto` | `NicoliveState` に `optional CreatorSupportGoalStatus creator_support_goal_status = 14;` 追加 + import |
| `data/message.proto` | creatorsupport の import 追加（上流定義どおり。実体での使用はなし） |
| `test/use-from-ts.test.ts` | `NicoliveState.creatorSupportGoalStatus` の encode/decode round-trip テストを追加 |

なお `FingerPrint` / `sensitive.proto`（`PreCensored`）は従来どおり `__REMOVE__` マーカーにより除去継続です。

## テスト

- `npm test` で round-trip テストが全パス（既存 moderatorUpdated + 新規 creatorSupportGoalStatus の 2 件）
- `npm run build` がエラーなく完了し、`dist/index.d.ts` に `CreatorSupportGoalStatus` / `GoalStatus` 型と enum 値 `CREATOR_SUPPORT_GOAL_ACHIRVEMENT` が生成されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)