### PR TITLE
feat: ndgr-edge-proto v2026.0629.180145 を取り込み (フィールド名・enum タイポ修正)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@n-air-app/nicolive-comment-protobuf",
-  "version": "2026.116.121242",
+  "version": "2026.616.161033",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@n-air-app/nicolive-comment-protobuf",
-      "version": "2026.116.121242",
+      "version": "2026.616.161033",
       "license": "MIT",
       "dependencies": {
         "protobufjs": "^8.6.3"

--- a/proto/dwango/nicolive/chat/data/atoms/creatorsupport.proto
+++ b/proto/dwango/nicolive/chat/data/atoms/creatorsupport.proto
@@ -4,7 +4,7 @@ package dwango.nicolive.chat.data.atoms;
 
 message CreatorSupportGoalStatus {
   
-  bool displayEnabled = 1;
+  bool display = 1;
 
   message GoalStatus {
     

--- a/proto/dwango/nicolive/chat/data/atoms/notifications.proto
+++ b/proto/dwango/nicolive/chat/data/atoms/notifications.proto
@@ -34,7 +34,7 @@ message SimpleNotificationV2 {
     USER_FOLLOW = 9;
 
     
-    CREATOR_SUPPORT_GOAL_ACHIRVEMENT = 10;
+    CREATOR_SUPPORT_GOAL_ACHIEVEMENT = 10;
   }
   
   NotificationType type = 1;

--- a/test/use-from-ts.test.ts
+++ b/test/use-from-ts.test.ts
@@ -72,7 +72,7 @@ describe('encode and decode', () => {
       {
         state: {
           creatorSupportGoalStatus: {
-            displayEnabled: true,
+            display: true,
             goalStatus: {
               rewardName: 'reward',
               rewardDisplayName: '目標達成報酬',


### PR DESCRIPTION
## 概要

ndgr-edge-proto の最新版に合わせて、以下 2 件のシンボル名修正を反映しました。
いずれもフィールド番号・enum 値は不変のため、既存の encode/decode とはバイト互換です。

## 変更内容

### `CreatorSupportGoalStatus` フィールド名変更

| ファイル | 変更 |
| --- | --- |
| `atoms/creatorsupport.proto` | `CreatorSupportGoalStatus.displayEnabled` → `display`（フィールド番号 1、wire 互換） |

### `SimpleNotificationV2.NotificationType` enum 値タイポ修正

| ファイル | 変更 |
| --- | --- |
| `atoms/notifications.proto` | `CREATOR_SUPPORT_GOAL_ACHIRVEMENT` → `CREATOR_SUPPORT_GOAL_ACHIEVEMENT`（enum 値 10、wire 互換） |

## テスト

- 既存の round-trip テストを `display` フィールド名に合わせて更新し、`npm test` 全パスを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)